### PR TITLE
Fix opening hours display and preserve location context

### DIFF
--- a/descuentosuy/src/app/api/update-branch-details/route.ts
+++ b/descuentosuy/src/app/api/update-branch-details/route.ts
@@ -79,7 +79,7 @@ export async function GET() {
 
   // 3. Iterar y actualizar cada sucursal, aplicando la lógica de caché
   for (const branch of branches) {
-    // @ts-ignore - Supabase types might not be perfect for nested selects
+    // @ts-expect-error - Supabase types might not be perfect for nested selects
     const details = branch.branch_details;
 
     // Si hay detalles y fueron actualizados hace menos de 3 meses, saltar

--- a/descuentosuy/src/app/page.tsx
+++ b/descuentosuy/src/app/page.tsx
@@ -33,19 +33,23 @@ type PageProps = {
 export default async function Home({ searchParams }: PageProps) {
   const { query, sort, lat, lon } = searchParams;
 
+  const userLocation = lat || lon ? { lat, lon } : undefined;
+
   const supabase = createPublicClient();
 
   // 1. Obtenemos la lista de SUCURSALES
-  const { data: branches, error } = await supabase.rpc('search_stores', {
+  const { data, error } = await supabase.rpc<Branch[]>('search_stores', {
     search_term: query || '',
     sort_option: sort || 'default',
     user_lat: lat ? parseFloat(lat) : null,
     user_lon: lon ? parseFloat(lon) : null,
-  }) as { data: Branch[], error: any };
+  });
 
   if (error) {
     return <p className="p-8 text-center text-red-500">Error al cargar los datos: {error.message}</p>;
   }
+
+  const branches = data ?? [];
 
   // 2. Creamos una lista de LOCALES únicos para la vista de tarjetas
   const uniqueStoresMap = new Map<string, Store>();
@@ -111,7 +115,7 @@ export default async function Home({ searchParams }: PageProps) {
       <main className="max-w-7xl mx-auto pb-12 px-4 sm:px-6 lg:px-8">
         <Suspense fallback={<div className="text-center col-span-full"><p>Cargando locales...</p></div>}>
           {/* 4. Pasamos la lista de locales ÚNICOS a la lista de tarjetas */}
-          <StoreList stores={uniqueStores} query={query} />
+          <StoreList stores={uniqueStores} query={query} userLocation={userLocation} />
         </Suspense>
       </main>
     </div>

--- a/descuentosuy/src/components/OpeningHours.tsx
+++ b/descuentosuy/src/components/OpeningHours.tsx
@@ -30,8 +30,9 @@ export function OpeningHours({ openingHours }: Props) {
     return null;
   }
 
-  const todayIndex = new Date().getDay();
-  
+  const jsDay = new Date().getDay();
+  const todayIndex = jsDay === 0 ? 6 : jsDay - 1;
+
   const todaysHoursText = openingHours.weekday_text[todayIndex] || '';
   const todaysHours = todaysHoursText.substring(todaysHoursText.indexOf(':') + 1).trim();
 
@@ -59,7 +60,9 @@ export function OpeningHours({ openingHours }: Props) {
           {statusText}
         </span>
         <span className="ml-2 text-gray-600">{todaysHours.replace('Closed', 'Cerrado')}</span>
-        <span className="ml-2 text-gray-400 transform transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}">▼</span>
+        <span className={`ml-2 text-gray-400 transform transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}>
+          ▼
+        </span>
       </div>
 
       {isOpen && (

--- a/descuentosuy/src/components/StoreCard.tsx
+++ b/descuentosuy/src/components/StoreCard.tsx
@@ -23,10 +23,34 @@ export type Store = {
   distance_km?: number; // Añadimos la distancia como opcional
 };
 
+export type UserLocation = {
+  lat?: string;
+  lon?: string;
+};
+
+type StoreCardProps = {
+  store: Store;
+  userLocation?: UserLocation;
+};
+
 // El componente de la tarjeta para un solo local, ahora envuelto en un Link
-export function StoreCard({ store }: { store: Store }) {
+export function StoreCard({ store, userLocation }: StoreCardProps) {
+  const queryParams = new URLSearchParams();
+
+  if (userLocation?.lat) {
+    queryParams.set('lat', userLocation.lat);
+  }
+
+  if (userLocation?.lon) {
+    queryParams.set('lon', userLocation.lon);
+  }
+
+  const href = queryParams.size > 0
+    ? `/local/${store.id}?${queryParams.toString()}`
+    : `/local/${store.id}`;
+
   return (
-    <Link href={`/local/${store.id}`} className="block h-full">
+    <Link href={href} className="block h-full">
       <div className="bg-white rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col h-full">
         {/* Logo del Local */}
         <div className="relative h-40 bg-gray-200 flex items-center justify-center">

--- a/descuentosuy/src/components/StoreList.tsx
+++ b/descuentosuy/src/components/StoreList.tsx
@@ -1,13 +1,14 @@
-import { StoreCard, type Store } from "@/components/StoreCard";
+import { StoreCard, type Store, type UserLocation } from "@/components/StoreCard";
 
 // Se define un tipo para las props, que ahora incluye la lista de locales.
 type StoreListProps = {
   stores: Store[];
   query?: string;
+  userLocation?: UserLocation;
 };
 
 // El componente ya no es asíncrono. Es un componente de presentación simple.
-export function StoreList({ stores, query }: StoreListProps) {
+export function StoreList({ stores, query, userLocation }: StoreListProps) {
   // La lógica de error y de "no resultados" ahora se maneja aquí,
   // basándose en los datos que se le pasan.
   if (!stores) {
@@ -28,7 +29,7 @@ export function StoreList({ stores, query }: StoreListProps) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
       {stores.map((store) => (
-        <StoreCard key={store.branch_id} store={store} />
+        <StoreCard key={store.branch_id} store={store} userLocation={userLocation} />
       ))}
     </div>
   );

--- a/descuentosuy/src/utils/leafletIconSetup.ts
+++ b/descuentosuy/src/utils/leafletIconSetup.ts
@@ -6,7 +6,7 @@ import markerIcon from 'leaflet/dist/images/marker-icon.png';
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
 // Configuramos el icono por defecto de Leaflet manualmente
-// @ts-ignore
+// @ts-expect-error - Leaflet typings no exponen la propiedad interna utilizada
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
     iconUrl: markerIcon.src,


### PR DESCRIPTION
## Summary
- align the opening-hours view with Google weekday ordering and ensure the toggle icon rotates correctly
- propagate the user latitude/longitude through store links so detail pages can compute distances
- clean up lint warnings by using ts-expect-error and avoiding implicit any types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cafda03c04832eb88632c10f6bff20