### PR TITLE
Broadcast geo state updates locally

### DIFF
--- a/descuentosuy/src/utils/locationStorage.ts
+++ b/descuentosuy/src/utils/locationStorage.ts
@@ -1,5 +1,6 @@
 export const GEO_META_KEY = 'descuentosuy:geo-meta';
 export const GEO_DENIED_KEY = 'descuentosuy:geo-denied';
+export const GEO_STATE_EVENT = 'descuentosuy:geo-state-change';
 
 export type GeoMetaSource = 'gps' | 'manual';
 
@@ -14,6 +15,13 @@ export type GeoMeta = {
 export type GeoState =
   | { status: 'denied'; updatedAt?: number }
   | ({ status?: 'granted' } & GeoMeta);
+
+function notifyGeoStateChange() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent(GEO_STATE_EVENT));
+}
 
 export function loadGeoState(): GeoState | null {
   if (typeof window === 'undefined') {
@@ -48,6 +56,7 @@ export function saveGeoMeta(meta: GeoMeta & { status?: 'granted' }) {
   window.sessionStorage.setItem(GEO_META_KEY, JSON.stringify(meta));
   window.sessionStorage.removeItem(GEO_DENIED_KEY);
   window.sessionStorage.removeItem(timestampKey);
+  notifyGeoStateChange();
 }
 
 export function markGeoDenied() {
@@ -58,6 +67,7 @@ export function markGeoDenied() {
   window.sessionStorage.setItem(GEO_DENIED_KEY, 'true');
   window.sessionStorage.setItem(timestampKey, Date.now().toString());
   window.sessionStorage.removeItem(GEO_META_KEY);
+  notifyGeoStateChange();
 }
 
 export function clearGeoState() {
@@ -68,4 +78,5 @@ export function clearGeoState() {
   window.sessionStorage.removeItem(GEO_META_KEY);
   window.sessionStorage.removeItem(GEO_DENIED_KEY);
   window.sessionStorage.removeItem(timestampKey);
+  notifyGeoStateChange();
 }


### PR DESCRIPTION
## Summary
- dispatch a geo state change custom event when persisting or clearing geo session storage
- listen for the custom event in LocationStatus so the overlay refreshes immediately within the same tab
- prioritize the permission denied message before other location status cases

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d58dcd2b80832ea3d9867a34a04e7a