### PR TITLE
Prevent filter chips from submitting the search form

### DIFF
--- a/descuentosuy/src/components/home/FilterChips.tsx
+++ b/descuentosuy/src/components/home/FilterChips.tsx
@@ -23,7 +23,7 @@ function Chip({ label, active, onClick, disabled }: ChipProps) {
   };
 
   return (
-    <button className={getClasses()} onClick={onClick} disabled={disabled}>
+    <button type="button" className={getClasses()} onClick={onClick} disabled={disabled}>
       {label}
     </button>
   );


### PR DESCRIPTION
## Summary
- set filter chip buttons to use `type="button"` so they no longer trigger form submissions when clicked inside the search form

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6b9e2ba18832e8ce470a222fba13a